### PR TITLE
Refactor bundle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ TODO
 
 ```yaml
 neusta_pimcore_http_cache:
-  # Enable/disable cache handling for certain element types
-  # (tagging and banning when elements of these types change).
-  asset: true
-  document: true
-  object: true
+    # Enable/disable cache handling for certain element types.
+    elements:
+        assets: true
+        documents: true
+        objects: true
 ```
 
 ## Contribution

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,10 +13,19 @@ final class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
+            ->fixXmlConfig('element')
             ->children()
-                ->booleanNode('asset')->defaultTrue()->end()
-                ->booleanNode('document')->defaultTrue()->end()
-                ->booleanNode('object')->defaultTrue()->end()
+                ->arrayNode('elements')
+                    ->addDefaultsIfNotSet()
+                    ->fixXmlConfig('asset')
+                    ->fixXmlConfig('document')
+                    ->fixXmlConfig('object')
+                    ->children()
+                        ->booleanNode('assets')->defaultTrue()->end()
+                        ->booleanNode('documents')->defaultTrue()->end()
+                        ->booleanNode('objects')->defaultTrue()->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/NeustaPimcoreHttpCacheExtension.php
+++ b/src/DependencyInjection/NeustaPimcoreHttpCacheExtension.php
@@ -20,20 +20,20 @@ final class NeustaPimcoreHttpCacheExtension extends ConfigurableExtension
 
         $loader->load('services.php');
 
-        if ($mergedConfig['document']) {
+        if ($mergedConfig['elements']['documents']) {
             $loader->load('document.php');
         }
-        if ($mergedConfig['asset']) {
+        if ($mergedConfig['elements']['assets']) {
             $loader->load('asset.php');
         }
-        if ($mergedConfig['object']) {
+        if ($mergedConfig['elements']['objects']) {
             $loader->load('object.php');
         }
 
         $container->getDefinition(StaticCacheTypeChecker::class)->setArgument('$types', [
-            ElementType::Asset->value => $mergedConfig['asset'],
-            ElementType::Object->value => $mergedConfig['object'],
-            ElementType::Document->value => $mergedConfig['document'],
+            ElementType::Asset->value => $mergedConfig['elements']['assets'],
+            ElementType::Object->value => $mergedConfig['elements']['objects'],
+            ElementType::Document->value => $mergedConfig['elements']['documents'],
         ]);
     }
 }


### PR DESCRIPTION
Moves Pimcore Element config under the “elements” node and uses plural names for the elements.

This matches the folder/namespace structure of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated cache configuration instructions to use a consolidated grouping for handling asset, document, and object options, making the settings clearer and more intuitive.
- **Refactor**
  - Streamlined internal configuration processing by replacing scattered boolean flags with a unified structure, ensuring consistency with the updated documentation.
  - Enhanced XML configuration handling for grouped settings, improving overall organization and access to configuration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->