### PR TITLE
Support custom cache types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ neusta_pimcore_http_cache:
         assets: true
         documents: true
         objects: true
+
+    # Enable/disable cache handling for custom cache types.
+    # Note that custom types MUST be defined (and enabled) here to be tagged/invalidated!
+    cache_types:
+        someType: true
+        otherType: false
 ```
 
 ## Contribution

--- a/src/Cache/CacheInvalidator.php
+++ b/src/Cache/CacheInvalidator.php
@@ -4,7 +4,6 @@ namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 
 use FOS\HttpCache\CacheInvalidator as FosCacheInvalidator;
 use Neusta\Pimcore\HttpCacheBundle\CacheActivator;
-use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
 use Pimcore\Model\Element\ElementInterface;
 
 final class CacheInvalidator implements CacheInvalidatorInterface
@@ -16,34 +15,9 @@ final class CacheInvalidator implements CacheInvalidatorInterface
     ) {
     }
 
-    public function invalidateElement(ElementInterface $element, ElementType $type): void
+    public function invalidateElement(ElementInterface $element): void
     {
-        if (!$this->cacheActivator->isCachingActive()) {
-            return;
-        }
-
-        if (!$this->typeChecker->isEnabled($type->value)) {
-            return;
-        }
-
-        $this->invalidator->invalidateTags([CacheTag::fromElement($element)->toString()]);
-    }
-
-    public function invalidateElementTags(CacheTags $tags, ElementType $type): void
-    {
-        if (!$this->cacheActivator->isCachingActive()) {
-            return;
-        }
-
-        if (!$this->typeChecker->isEnabled($type->value)) {
-            return;
-        }
-
-        if ($tags->isEmpty()) {
-            return;
-        }
-
-        $this->invalidator->invalidateTags($tags->toArray());
+        $this->invalidateTags(CacheTags::fromElements([$element]));
     }
 
     public function invalidateTags(CacheTags $tags): void
@@ -51,6 +25,8 @@ final class CacheInvalidator implements CacheInvalidatorInterface
         if (!$this->cacheActivator->isCachingActive()) {
             return;
         }
+
+        $tags = $tags->onlyEnabled($this->typeChecker);
 
         if ($tags->isEmpty()) {
             return;

--- a/src/Cache/CacheInvalidatorInterface.php
+++ b/src/Cache/CacheInvalidatorInterface.php
@@ -2,14 +2,11 @@
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 
-use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
 use Pimcore\Model\Element\ElementInterface;
 
 interface CacheInvalidatorInterface
 {
-    public function invalidateElement(ElementInterface $element, ElementType $type): void;
-
-    public function invalidateElementTags(CacheTags $tags, ElementType $type): void;
+    public function invalidateElement(ElementInterface $element): void;
 
     public function invalidateTags(CacheTags $tags): void;
 }

--- a/src/Cache/CacheTags.php
+++ b/src/Cache/CacheTags.php
@@ -35,6 +35,11 @@ final class CacheTags implements \IteratorAggregate
         return new \ArrayIterator($this->tags);
     }
 
+    public function onlyEnabled(CacheTypeChecker $checker): self
+    {
+        return new self(...array_filter($this->tags, fn (CacheTag $tag) => $tag->isEnabled($checker)));
+    }
+
     /**
      * @return string[]
      */

--- a/src/Cache/CacheType.php
+++ b/src/Cache/CacheType.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\CustomCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\ElementCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\EmptyCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
+use Pimcore\Model\Element\ElementInterface;
+
+final class CacheType
+{
+    private function __construct(
+        private readonly EmptyCacheType|ElementCacheType|CustomCacheType $type,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(new EmptyCacheType());
+    }
+
+    public static function fromString(string $type): self
+    {
+        if (ElementCacheType::isReserved($type)) {
+            throw new \InvalidArgumentException('The given cache type is reserved for Pimcore Elements.');
+        }
+
+        if ($elementType = ElementType::tryFrom($type)) {
+            return new self(new ElementCacheType($elementType));
+        }
+
+        return new self(new CustomCacheType($type));
+    }
+
+    public static function fromElement(ElementInterface $element): self
+    {
+        return new self(new ElementCacheType(ElementType::fromElement($element)));
+    }
+
+    public function isEnabled(CacheTypeChecker $checker): bool
+    {
+        return $this->type instanceof EmptyCacheType || $checker->isEnabled($this);
+    }
+
+    public function applyTo(string $tag): string
+    {
+        return $this->type->applyTo($tag);
+    }
+
+    public function toString(): string
+    {
+        return $this->type->toString();
+    }
+}

--- a/src/Cache/CacheType/CustomCacheType.php
+++ b/src/Cache/CacheType/CustomCacheType.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
+
+/**
+ * @internal
+ */
+final class CustomCacheType
+{
+    public function __construct(
+        private readonly string $type,
+    ) {
+    }
+
+    public function applyTo(string $tag): string
+    {
+        return $this->type . '-' . $tag;
+    }
+
+    public function toString(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/Cache/CacheType/ElementCacheType.php
+++ b/src/Cache/CacheType/ElementCacheType.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
+
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
+
+/**
+ * @internal
+ */
+final class ElementCacheType
+{
+    public function __construct(
+        private readonly ElementType $type,
+    ) {
+    }
+
+    public static function isReserved(string $value): bool
+    {
+        static $prefixes;
+        $prefixes ??= array_map(fn (string $value) => $value[0], array_column(ElementType::cases(), 'value'));
+
+        return \in_array($value, $prefixes, true);
+    }
+
+    public function applyTo(string $tag): string
+    {
+        return $this->type->value[0] . $tag;
+    }
+
+    public function toString(): string
+    {
+        return $this->type->value;
+    }
+}

--- a/src/Cache/CacheType/EmptyCacheType.php
+++ b/src/Cache/CacheType/EmptyCacheType.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
+
+/**
+ * @internal
+ */
+final class EmptyCacheType
+{
+    public function __construct()
+    {
+    }
+
+    public function applyTo(string $tag): string
+    {
+        return $tag;
+    }
+
+    public function toString(): string
+    {
+        return '';
+    }
+}

--- a/src/Cache/CacheTypeChecker.php
+++ b/src/Cache/CacheTypeChecker.php
@@ -5,5 +5,5 @@ namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 
 interface CacheTypeChecker
 {
-    public function isEnabled(string $type): bool;
+    public function isEnabled(CacheType $type): bool;
 }

--- a/src/Cache/StaticCacheTypeChecker.php
+++ b/src/Cache/StaticCacheTypeChecker.php
@@ -12,8 +12,8 @@ final class StaticCacheTypeChecker implements CacheTypeChecker
     ) {
     }
 
-    public function isEnabled(string $type): bool
+    public function isEnabled(CacheType $type): bool
     {
-        return $this->types[$type] ?? false;
+        return $this->types[$type->toString()] ?? false;
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->fixXmlConfig('element')
+            ->fixXmlConfig('cache_type')
             ->children()
                 ->arrayNode('elements')
                     ->addDefaultsIfNotSet()
@@ -25,6 +26,12 @@ final class Configuration implements ConfigurationInterface
                         ->booleanNode('documents')->defaultTrue()->end()
                         ->booleanNode('objects')->defaultTrue()->end()
                     ->end()
+                ->end()
+                ->arrayNode('cache_types')
+                    ->info('Enable/disable cache handling for custom cache types.')
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('type')
+                    ->booleanPrototype()->end()
                 ->end()
             ->end();
 

--- a/src/DependencyInjection/NeustaPimcoreHttpCacheExtension.php
+++ b/src/DependencyInjection/NeustaPimcoreHttpCacheExtension.php
@@ -34,6 +34,6 @@ final class NeustaPimcoreHttpCacheExtension extends ConfigurableExtension
             ElementType::Asset->value => $mergedConfig['elements']['assets'],
             ElementType::Object->value => $mergedConfig['elements']['objects'],
             ElementType::Document->value => $mergedConfig['elements']['documents'],
-        ]);
+        ] + $mergedConfig['cache_types']);
     }
 }

--- a/src/Element/InvalidateElementListener.php
+++ b/src/Element/InvalidateElementListener.php
@@ -38,7 +38,7 @@ final class InvalidateElementListener
             return;
         }
 
-        $this->cacheInvalidator->invalidateElement($invalidationEvent->element, $invalidationEvent->elementType);
-        $this->cacheInvalidator->invalidateElementTags($invalidationEvent->cacheTags, $invalidationEvent->elementType);
+        $this->cacheInvalidator->invalidateElement($invalidationEvent->element);
+        $this->cacheInvalidator->invalidateTags($invalidationEvent->cacheTags);
     }
 }

--- a/tests/Unit/Cache/CacheInvalidatorTest.php
+++ b/tests/Unit/Cache/CacheInvalidatorTest.php
@@ -6,12 +6,13 @@ use FOS\HttpCacheBundle\CacheManager;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheInvalidator;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTags;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTypeChecker;
 use Neusta\Pimcore\HttpCacheBundle\CacheActivator;
 use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
 use PHPUnit\Framework\TestCase;
+use Pimcore\Model\Asset;
 use Pimcore\Model\Document;
-use Pimcore\Model\Element\ElementInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -48,14 +49,14 @@ final class CacheInvalidatorTest extends TestCase
      */
     public function invalidateElement_should_invalidate_element_for_given_type(): void
     {
-        $element = $this->prophesize(ElementInterface::class);
+        $element = $this->prophesize(Asset::class);
         $element->getId()->willReturn(42);
         $tag = CacheTag::fromElement($element->reveal());
 
         $this->cacheActivator->isCachingActive()->willReturn(true);
-        $this->typeChecker->isEnabled(ElementType::Asset->value)->willReturn(true);
+        $this->typeChecker->isEnabled(CacheType::fromString(ElementType::Asset->value))->willReturn(true);
 
-        $this->cacheInvalidator->invalidateElement($element->reveal(), ElementType::Asset);
+        $this->cacheInvalidator->invalidateElement($element->reveal());
 
         $this->cacheManager->invalidateTags([$tag->toString()])->shouldHaveBeenCalledOnce();
     }
@@ -65,11 +66,12 @@ final class CacheInvalidatorTest extends TestCase
      */
     public function invalidateElement_should_not_invalidate_element_when_caching_is_not_active(): void
     {
-        $element = $this->prophesize(ElementInterface::class);
+        $element = $this->prophesize(Asset::class);
+        $element->getId()->willReturn(42);
 
         $this->cacheActivator->isCachingActive()->willReturn(false);
 
-        $this->cacheInvalidator->invalidateElement($element->reveal(), ElementType::Asset);
+        $this->cacheInvalidator->invalidateElement($element->reveal());
 
         $this->cacheManager->invalidateTags(Argument::any())->shouldNotHaveBeenCalled();
     }
@@ -77,7 +79,7 @@ final class CacheInvalidatorTest extends TestCase
     /**
      * @test
      */
-    public function invalidateElementTags_should_invalidate_tags_for_given_type(): void
+    public function invalidateTags_should_invalidate_tags_for_given_type(): void
     {
         $document1 = $this->prophesize(Document::class);
         $document2 = $this->prophesize(Document::class);
@@ -89,9 +91,9 @@ final class CacheInvalidatorTest extends TestCase
             $document2->reveal(),
         ]);
         $this->cacheActivator->isCachingActive()->willReturn(true);
-        $this->typeChecker->isEnabled(ElementType::Asset->value)->willReturn(true);
+        $this->typeChecker->isEnabled(CacheType::fromString(ElementType::Document->value))->willReturn(true);
 
-        $this->cacheInvalidator->invalidateElementTags($tags, ElementType::Asset);
+        $this->cacheInvalidator->invalidateTags($tags);
 
         $this->cacheManager->invalidateTags([
             CacheTag::fromElement($document1->reveal())->toString(),
@@ -102,35 +104,13 @@ final class CacheInvalidatorTest extends TestCase
     /**
      * @test
      */
-    public function invalidateElementTags_should_not_invalidate_tags_when_caching_is_not_active(): void
-    {
-        $document1 = $this->prophesize(Document::class);
-        $document2 = $this->prophesize(Document::class);
-
-        $document1->getId()->willReturn(42);
-        $document2->getId()->willReturn(43);
-        $tags = CacheTags::fromElements([
-            $document1->reveal(),
-            $document2->reveal(),
-        ]);
-        $this->cacheActivator->isCachingActive()->willReturn(false);
-
-        $this->cacheInvalidator->invalidateElementTags($tags, ElementType::Document);
-
-        $this->cacheManager->invalidateTags(Argument::any())->shouldNotHaveBeenCalled();
-    }
-
-    /**
-     * @test
-     */
-    public function invalidateElementTags_should_not_invalidate_tags_when_tags_are_empty(): void
+    public function invalidateTags_should_not_invalidate_tags_when_tags_are_empty(): void
     {
         $tags = new CacheTags();
 
         $this->cacheActivator->isCachingActive()->willReturn(true);
-        $this->typeChecker->isEnabled(ElementType::Document->value)->willReturn(true);
 
-        $this->cacheInvalidator->invalidateElementTags($tags, ElementType::Document);
+        $this->cacheInvalidator->invalidateTags($tags);
 
         $this->cacheManager->invalidateTags(Argument::any())->shouldNotHaveBeenCalled();
     }
@@ -140,7 +120,7 @@ final class CacheInvalidatorTest extends TestCase
      */
     public function invalidateTags_should_invalidate_tags(): void
     {
-        $tags = new CacheTags(new CacheTag('tag1'), new CacheTag('tag2'));
+        $tags = new CacheTags(CacheTag::fromString('tag1'), CacheTag::fromString('tag2'));
 
         $this->cacheActivator->isCachingActive()->willReturn(true);
 
@@ -154,23 +134,9 @@ final class CacheInvalidatorTest extends TestCase
      */
     public function invalidateTags_should_not_invalidate_tags_when_caching_is_not_active(): void
     {
-        $tags = new CacheTags(new CacheTag('tag1'), new CacheTag('tag2'));
+        $tags = new CacheTags(CacheTag::fromString('tag1'), CacheTag::fromString('tag2'));
 
         $this->cacheActivator->isCachingActive()->willReturn(false);
-
-        $this->cacheInvalidator->invalidateTags($tags);
-
-        $this->cacheManager->invalidateTags(Argument::any())->shouldNotHaveBeenCalled();
-    }
-
-    /**
-     * @test
-     */
-    public function invalidateTags_should_not_invalidate_tags_when_tags_are_empty(): void
-    {
-        $tags = new CacheTags();
-
-        $this->cacheActivator->isCachingActive()->willReturn(true);
 
         $this->cacheInvalidator->invalidateTags($tags);
 

--- a/tests/Unit/Element/InvalidateElementListenerTest.php
+++ b/tests/Unit/Element/InvalidateElementListenerTest.php
@@ -7,7 +7,6 @@ use Neusta\Pimcore\HttpCacheBundle\Cache\CacheInvalidatorInterface;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTags;
 use Neusta\Pimcore\HttpCacheBundle\Element\ElementInvalidationEvent;
-use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
 use Neusta\Pimcore\HttpCacheBundle\Element\InvalidateElementListener;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Event\Model\AssetEvent;
@@ -100,13 +99,12 @@ final class InvalidateElementListenerTest extends TestCase
     public function onUpdated_should_invalidate_elements(ElementEventInterface $event): void
     {
         $element = $event->getElement();
-        $elementType = ElementType::fromElement($element);
 
         $this->invalidateElementListener->onUpdated($event);
 
-        $this->cacheInvalidator->invalidateElement($element, $elementType)
+        $this->cacheInvalidator->invalidateElement($element)
             ->shouldHaveBeenCalledOnce();
-        $this->cacheInvalidator->invalidateElementTags(Argument::type(CacheTags::class), $elementType)
+        $this->cacheInvalidator->invalidateTags(Argument::type(CacheTags::class))
             ->shouldHaveBeenCalledOnce();
     }
 
@@ -118,7 +116,6 @@ final class InvalidateElementListenerTest extends TestCase
     public function onUpdated_should_not_invalidate_when_event_was_canceled(ElementEventInterface $event): void
     {
         $element = $event->getElement();
-        $elementType = ElementType::fromElement($element);
         $invalidationEvent = ElementInvalidationEvent::fromElement($element);
         $invalidationEvent->cancel = true;
 
@@ -127,9 +124,9 @@ final class InvalidateElementListenerTest extends TestCase
 
         $this->invalidateElementListener->onUpdated($event);
 
-        $this->cacheInvalidator->invalidateElement($element, $elementType)
+        $this->cacheInvalidator->invalidateElement($element)
             ->shouldNotHaveBeenCalled();
-        $this->cacheInvalidator->invalidateElementTags(Argument::type(CacheTags::class), $elementType)
+        $this->cacheInvalidator->invalidateTags(Argument::type(CacheTags::class))
             ->shouldNotHaveBeenCalled();
     }
 
@@ -141,19 +138,18 @@ final class InvalidateElementListenerTest extends TestCase
     public function onUpdated_should_invalidate_additional_tags_when_requested(ElementEventInterface $event): void
     {
         $element = $event->getElement();
-        $elementType = ElementType::fromElement($element);
         $invalidationEvent = ElementInvalidationEvent::fromElement($element);
-        $invalidationEvent->cacheTags->add(new CacheTag('tag1'));
-        $invalidationEvent->cacheTags->add(new CacheTag('tag2'));
+        $invalidationEvent->cacheTags->add(CacheTag::fromString('tag1'));
+        $invalidationEvent->cacheTags->add(CacheTag::fromString('tag2'));
 
         $this->eventDispatcher->dispatch(Argument::type(ElementInvalidationEvent::class))
             ->willReturn($invalidationEvent);
 
         $this->invalidateElementListener->onUpdated($event);
 
-        $this->cacheInvalidator->invalidateElement($element, $elementType)
+        $this->cacheInvalidator->invalidateElement($element)
             ->shouldHaveBeenCalledOnce();
-        $this->cacheInvalidator->invalidateElementTags($invalidationEvent->cacheTags, $elementType)
+        $this->cacheInvalidator->invalidateTags($invalidationEvent->cacheTags)
             ->shouldHaveBeenCalledOnce();
     }
 
@@ -178,13 +174,12 @@ final class InvalidateElementListenerTest extends TestCase
     public function onDeleted_should_invalidate_elements(ElementEventInterface $event): void
     {
         $element = $event->getElement();
-        $elementType = ElementType::fromElement($element);
 
         $this->invalidateElementListener->onDeleted($event);
 
-        $this->cacheInvalidator->invalidateElement($element, $elementType)
+        $this->cacheInvalidator->invalidateElement($element)
             ->shouldHaveBeenCalledOnce();
-        $this->cacheInvalidator->invalidateElementTags(Argument::type(CacheTags::class), $elementType)
+        $this->cacheInvalidator->invalidateTags(Argument::type(CacheTags::class))
             ->shouldHaveBeenCalledOnce();
     }
 
@@ -196,7 +191,6 @@ final class InvalidateElementListenerTest extends TestCase
     public function onDeleted_should_not_invalidate_when_event_was_canceled(ElementEventInterface $event): void
     {
         $element = $event->getElement();
-        $elementType = ElementType::fromElement($element);
         $invalidationEvent = ElementInvalidationEvent::fromElement($element);
         $invalidationEvent->cancel = true;
 
@@ -205,9 +199,9 @@ final class InvalidateElementListenerTest extends TestCase
 
         $this->invalidateElementListener->onDeleted($event);
 
-        $this->cacheInvalidator->invalidateElement($element, $elementType)
+        $this->cacheInvalidator->invalidateElement($element)
             ->shouldNotHaveBeenCalled();
-        $this->cacheInvalidator->invalidateElementTags(Argument::type(CacheTags::class), $elementType)
+        $this->cacheInvalidator->invalidateTags(Argument::type(CacheTags::class))
             ->shouldNotHaveBeenCalled();
     }
 
@@ -219,19 +213,18 @@ final class InvalidateElementListenerTest extends TestCase
     public function onDeleted_should_invalidate_additional_tags_when_requested(ElementEventInterface $event): void
     {
         $element = $event->getElement();
-        $elementType = ElementType::fromElement($element);
         $invalidationEvent = ElementInvalidationEvent::fromElement($element);
-        $invalidationEvent->cacheTags->add(new CacheTag('tag1'));
-        $invalidationEvent->cacheTags->add(new CacheTag('tag2'));
+        $invalidationEvent->cacheTags->add(CacheTag::fromString('tag1'));
+        $invalidationEvent->cacheTags->add(CacheTag::fromString('tag2'));
 
         $this->eventDispatcher->dispatch(Argument::type(ElementInvalidationEvent::class))
             ->willReturn($invalidationEvent);
 
         $this->invalidateElementListener->onDeleted($event);
 
-        $this->cacheInvalidator->invalidateElement($element, $elementType)
+        $this->cacheInvalidator->invalidateElement($element)
             ->shouldHaveBeenCalledOnce();
-        $this->cacheInvalidator->invalidateElementTags($invalidationEvent->cacheTags, $elementType)
+        $this->cacheInvalidator->invalidateTags($invalidationEvent->cacheTags)
             ->shouldHaveBeenCalledOnce();
     }
 

--- a/tests/Unit/Element/Object/TagObjectListenerTest.php
+++ b/tests/Unit/Element/Object/TagObjectListenerTest.php
@@ -9,6 +9,7 @@ use Neusta\Pimcore\HttpCacheBundle\Element\Object\TagObjectListener;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\Folder;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -41,12 +42,12 @@ final class TagObjectListenerTest extends TestCase
     public function it_should_tag_elements_of_type_object(): void
     {
         $object = $this->prophesize(DataObject::class);
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn('object');
         $objectEvent = new DataObjectEvent($object->reveal());
-        $cacheTag = new CacheTag('o42');
+        $cacheTag = CacheTag::fromElement($object->reveal());
 
         $this->cacheActivator->isCachingActive()->willReturn(true);
-        $object->getType()->willReturn('object');
-        $object->getId()->willReturn(42);
 
         ($this->tagObjectListener)($objectEvent);
 
@@ -58,7 +59,7 @@ final class TagObjectListenerTest extends TestCase
      */
     public function it_should_not_tag_objects_of_type_folder(): void
     {
-        $object = $this->prophesize(DataObject::class);
+        $object = $this->prophesize(Folder::class);
         $objectEvent = new DataObjectEvent($object->reveal());
 
         $this->cacheActivator->isCachingActive()->willReturn(true);


### PR DESCRIPTION
Elevates cache types to a general feature that is not only reserved for Pimcore Elements.

Users can add custom types to their tags and enable/disable them via the bundle config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new configuration section detailing options for enabling/disabling custom cache types.
- **New Features**
  - Enhanced support for custom cache types with configurable enabled/disabled states.
- **Refactor**
  - Streamlined cache invalidation and tag filtering processes for improved efficiency.
- **Tests**
  - Updated test cases to validate the refined caching behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->