### PR TITLE
Refactor tests to add a base config for the bundle

### DIFF
--- a/tests/Integration/Invalidation/CancelInvalidationTest.php
+++ b/tests/Integration/Invalidation/CancelInvalidationTest.php
@@ -44,8 +44,6 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]
@@ -63,9 +61,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function cancel_invalidation_on_document_update(): void
@@ -83,8 +79,6 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function cancel_invalidation_on_asset_update(): void
@@ -101,8 +95,6 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]
@@ -120,9 +112,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function cancel_invalidation_on_document_delete(): void
@@ -140,8 +130,6 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function cancel_invalidation_on_asset_delete(): void

--- a/tests/Integration/Invalidation/InvalidateAdditionalTagTest.php
+++ b/tests/Integration/Invalidation/InvalidateAdditionalTagTest.php
@@ -46,8 +46,6 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]
@@ -65,9 +63,7 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function invalidate_additional_tag_on_document_update(): void
@@ -85,8 +81,6 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function invalidate_additional_tag_on_asset_update(): void
@@ -103,8 +97,6 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]
@@ -123,8 +115,6 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function invalidate_additional_tag_on_asset_deletion(): void
@@ -141,9 +131,7 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function invalidate_additional_tag_on_document_deletion(): void

--- a/tests/Integration/Invalidation/InvalidateAssetTest.php
+++ b/tests/Integration/Invalidation/InvalidateAssetTest.php
@@ -40,8 +40,6 @@ final class InvalidateAssetTest extends ConfigurableKernelTestCase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function response_is_invalidated_when_asset_is_updated(): void
@@ -57,8 +55,6 @@ final class InvalidateAssetTest extends ConfigurableKernelTestCase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function response_is_invalidated_when_asset_is_deleted(): void

--- a/tests/Integration/Invalidation/InvalidateDocumentTest.php
+++ b/tests/Integration/Invalidation/InvalidateDocumentTest.php
@@ -38,9 +38,7 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_invalidated_when_document_is_updated(): void
@@ -55,9 +53,7 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_invalidated_when_document_is_deleted(): void

--- a/tests/Integration/Invalidation/InvalidateObjectTest.php
+++ b/tests/Integration/Invalidation/InvalidateObjectTest.php
@@ -38,8 +38,6 @@ final class InvalidateObjectTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]
@@ -55,8 +53,6 @@ final class InvalidateObjectTest extends ConfigurableKernelTestCase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]

--- a/tests/Integration/Tagging/TagAssetTest.php
+++ b/tests/Integration/Tagging/TagAssetTest.php
@@ -28,8 +28,6 @@ final class TagAssetTest extends ConfigurableWebTestcase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function response_is_tagged_with_expected_tags_when_asset_is_loaded(): void
@@ -52,8 +50,6 @@ final class TagAssetTest extends ConfigurableWebTestcase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => false,
-            'documents' => false,
-            'objects' => true,
         ],
     ])]
     public function response_is_not_tagged_when_assets_is_not_enabled(): void
@@ -76,8 +72,6 @@ final class TagAssetTest extends ConfigurableWebTestcase
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
             'assets' => true,
-            'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function response_is_not_tagged_when_caching_is_deactivated(): void

--- a/tests/Integration/Tagging/TagDocumentTest.php
+++ b/tests/Integration/Tagging/TagDocumentTest.php
@@ -27,9 +27,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_tagged_with_expected_tags_when_page_is_loaded(): void
@@ -51,9 +49,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_tagged_with_expected_tags_when_snippet_is_loaded(): void
@@ -75,9 +71,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_not_tagged_when_document_type_is_email(): void
@@ -99,9 +93,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_not_tagged_when_document_type_is_hard_link(): void
@@ -123,9 +115,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_not_tagged_when_document_type_is_folder(): void
@@ -147,9 +137,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => false,
-            'objects' => false,
         ],
     ])]
     public function response_is_not_tagged_when_documents_is_not_enabled(): void
@@ -171,9 +159,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function response_is_not_tagged_when_caching_is_deactivated(): void
@@ -197,9 +183,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
             'documents' => true,
-            'objects' => false,
         ],
     ])]
     public function request_is_tagged_with_root_document_tag_when_loaded(): void

--- a/tests/Integration/Tagging/TagObjectTest.php
+++ b/tests/Integration/Tagging/TagObjectTest.php
@@ -27,8 +27,6 @@ final class TagObjectTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]
@@ -51,8 +49,6 @@ final class TagObjectTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => false,
         ],
     ])]
@@ -75,8 +71,6 @@ final class TagObjectTest extends ConfigurableWebTestcase
      */
     #[ConfigureExtension('neusta_pimcore_http_cache', [
         'elements' => [
-            'assets' => false,
-            'documents' => false,
             'objects' => true,
         ],
     ])]

--- a/tests/app/config/packages/neusta_pimcore_http_cache.yaml
+++ b/tests/app/config/packages/neusta_pimcore_http_cache.yaml
@@ -1,0 +1,5 @@
+neusta_pimcore_http_cache:
+  elements:
+    assets: false
+    documents: false
+    objects: false


### PR DESCRIPTION
I find it difficult to see which elements are enabled or disabled per test, as all elements are specified each time.

So I thought it might be better to disable *everything* by default and then only enable the elements that are relevant in each test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified test configurations by removing explicit disabling of unused cache elements in multiple test classes.
	- Added a new configuration file to explicitly disable caching for assets, documents, and objects in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->