### PR TITLE
Arrange test setup in isolation

### DIFF
--- a/tests/Integration/Helpers/ArrangeCacheTest.php
+++ b/tests/Integration/Helpers/ArrangeCacheTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers;
+
+use Neusta\Pimcore\HttpCacheBundle\CacheActivator;
+
+trait ArrangeCacheTest
+{
+    /**
+     * Lets you prepare the prerequisites for your test without interfering with the caching.
+     *
+     * @template T
+     *
+     * @param \Closure():T $arrange
+     *
+     * @return T
+     */
+    public static function arrange(\Closure $arrange): mixed
+    {
+        $cacheActivator = self::getContainer()->get(CacheActivator::class);
+        \assert($cacheActivator instanceof CacheActivator);
+
+        $wasActive = $cacheActivator->isCachingActive();
+        $cacheActivator->deactivateCaching();
+        try {
+            return $arrange();
+        } finally {
+            $wasActive && $cacheActivator->activateCaching();
+        }
+    }
+}

--- a/tests/Integration/Helpers/ArrangeCacheTest.php
+++ b/tests/Integration/Helpers/ArrangeCacheTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers;
 

--- a/tests/Integration/Invalidation/CancelInvalidationTest.php
+++ b/tests/Integration/Invalidation/CancelInvalidationTest.php
@@ -4,6 +4,7 @@ namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Invalidation;
 
 use FOS\HttpCacheBundle\CacheManager;
 use Neusta\Pimcore\HttpCacheBundle\Element\ElementInvalidationEvent;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestAssetFactory;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestDocumentFactory;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestObjectFactory;
@@ -22,6 +23,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 ]
 final class CancelInvalidationTest extends ConfigurableKernelTestCase
 {
+    use ArrangeCacheTest;
     use ProphecyTrait;
     use ResetDatabase;
 
@@ -51,7 +53,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     ])]
     public function cancel_invalidation_on_object_update(): void
     {
-        $object = TestObjectFactory::simple()->save();
+        $object = self::arrange(fn () => TestObjectFactory::simple()->save());
 
         $object->setContent('Updated test content')->save();
 
@@ -70,7 +72,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     ])]
     public function cancel_invalidation_on_document_update(): void
     {
-        $document = TestDocumentFactory::simplePage()->save();
+        $document = self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $document->setKey('updated_test_document_page')->save();
 
@@ -89,7 +91,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     ])]
     public function cancel_invalidation_on_asset_update(): void
     {
-        $asset = TestAssetFactory::simple()->save();
+        $asset = self::arrange(fn () => TestAssetFactory::simple()->save());
 
         $asset->setData('Updated test content')->save();
 
@@ -108,7 +110,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     ])]
     public function cancel_invalidation_on_object_delete(): void
     {
-        $object = TestObjectFactory::simple()->save();
+        $object = self::arrange(fn () => TestObjectFactory::simple()->save());
 
         $object->delete();
 
@@ -127,7 +129,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     ])]
     public function cancel_invalidation_on_document_delete(): void
     {
-        $document = TestDocumentFactory::simplePage()->save();
+        $document = self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $document->delete();
 
@@ -146,7 +148,7 @@ final class CancelInvalidationTest extends ConfigurableKernelTestCase
     ])]
     public function cancel_invalidation_on_asset_delete(): void
     {
-        $asset = TestAssetFactory::simple()->save();
+        $asset = self::arrange(fn () => TestAssetFactory::simple()->save());
 
         $asset->delete();
 

--- a/tests/Integration/Invalidation/InvalidateAdditionalTagTest.php
+++ b/tests/Integration/Invalidation/InvalidateAdditionalTagTest.php
@@ -5,6 +5,7 @@ namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Invalidation;
 use FOS\HttpCacheBundle\CacheManager;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
 use Neusta\Pimcore\HttpCacheBundle\Element\ElementInvalidationEvent;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestAssetFactory;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestDocumentFactory;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestObjectFactory;
@@ -23,6 +24,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 ]
 final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
 {
+    use ArrangeCacheTest;
     use ProphecyTrait;
     use ResetDatabase;
 
@@ -53,11 +55,11 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     ])]
     public function invalidate_additional_tag_on_object_update(): void
     {
-        $object = TestObjectFactory::simple()->save();
+        $object = self::arrange(fn () => TestObjectFactory::simple()->save());
 
         $object->setContent('Updated test content')->save();
 
-        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -72,11 +74,11 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     ])]
     public function invalidate_additional_tag_on_document_update(): void
     {
-        $document = TestDocumentFactory::simplePage()->save();
+        $document = self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $document->setKey('updated_test_document_page')->save();
 
-        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -91,11 +93,11 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     ])]
     public function invalidate_additional_tag_on_asset_update(): void
     {
-        $asset = TestAssetFactory::simple()->save();
+        $asset = self::arrange(fn () => TestAssetFactory::simple()->save());
 
         $asset->setData('Updated test content')->save();
 
-        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -110,11 +112,11 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     ])]
     public function invalidate_additional_tag_on_object_deletion(): void
     {
-        $object = TestObjectFactory::simple()->save();
+        $object = self::arrange(fn () => TestObjectFactory::simple()->save());
 
         $object->delete();
 
-        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -129,11 +131,11 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     ])]
     public function invalidate_additional_tag_on_asset_deletion(): void
     {
-        $asset = TestAssetFactory::simple()->save();
+        $asset = self::arrange(fn () => TestAssetFactory::simple()->save());
 
         $asset->delete();
 
-        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -148,10 +150,10 @@ final class InvalidateAdditionalTagTest extends ConfigurableKernelTestCase
     ])]
     public function invalidate_additional_tag_on_document_deletion(): void
     {
-        $document = TestDocumentFactory::simplePage()->save();
+        $document = self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $document->delete();
 
-        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['additional_tag'])->shouldHaveBeenCalledTimes(1);
     }
 }

--- a/tests/Integration/Invalidation/InvalidateAssetTest.php
+++ b/tests/Integration/Invalidation/InvalidateAssetTest.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Invalidation;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestAssetFactory;
 use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
@@ -16,6 +17,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 #[ConfigureRoute(__DIR__ . '/../Fixtures/get_asset_route.php')]
 final class InvalidateAssetTest extends ConfigurableKernelTestCase
 {
+    use ArrangeCacheTest;
     use ProphecyTrait;
     use ResetDatabase;
 
@@ -30,8 +32,7 @@ final class InvalidateAssetTest extends ConfigurableKernelTestCase
         $this->cacheManager->invalidateTags(Argument::any())->willReturn($this->cacheManager->reveal());
         self::getContainer()->set('fos_http_cache.cache_manager', $this->cacheManager->reveal());
 
-        $this->asset = TestAssetFactory::simple()->save();
-        parent::setUp();
+        $this->asset = self::arrange(fn () => TestAssetFactory::simple()->save());
     }
 
     /**
@@ -48,7 +49,7 @@ final class InvalidateAssetTest extends ConfigurableKernelTestCase
     {
         $this->asset->setData('Updated test content')->save();
 
-        $this->cacheManager->invalidateTags(['a42'])->shouldHaveBeenCalledTimes(2);
+        $this->cacheManager->invalidateTags(['a42'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -65,6 +66,6 @@ final class InvalidateAssetTest extends ConfigurableKernelTestCase
     {
         $this->asset->delete();
 
-        $this->cacheManager->invalidateTags(['a42'])->shouldHaveBeenCalledTimes(2);
+        $this->cacheManager->invalidateTags(['a42'])->shouldHaveBeenCalledTimes(1);
     }
 }

--- a/tests/Integration/Invalidation/InvalidateDocumentTest.php
+++ b/tests/Integration/Invalidation/InvalidateDocumentTest.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Invalidation;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestDocumentFactory;
 use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
@@ -16,6 +17,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 #[ConfigureRoute(__DIR__ . '/../Fixtures/get_document_route.php')]
 final class InvalidateDocumentTest extends ConfigurableKernelTestCase
 {
+    use ArrangeCacheTest;
     use ProphecyTrait;
     use ResetDatabase;
 
@@ -30,7 +32,7 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
         $this->cacheManager->invalidateTags(Argument::any())->willReturn($this->cacheManager->reveal());
         self::getContainer()->set('fos_http_cache.cache_manager', $this->cacheManager->reveal());
 
-        $this->document = TestDocumentFactory::simplePage()->save();
+        $this->document = self::arrange(fn () => TestDocumentFactory::simplePage()->save());
     }
 
     /**
@@ -47,7 +49,7 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
     {
         $this->document->setKey('updated_test_document_page')->save();
 
-        $this->cacheManager->invalidateTags(['d42'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['d42'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -64,6 +66,6 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
     {
         $this->document->delete();
 
-        $this->cacheManager->invalidateTags(['d42'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['d42'])->shouldHaveBeenCalledTimes(1);
     }
 }

--- a/tests/Integration/Invalidation/InvalidateObjectTest.php
+++ b/tests/Integration/Invalidation/InvalidateObjectTest.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Invalidation;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestObjectFactory;
 use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
@@ -16,6 +17,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 #[ConfigureRoute(__DIR__ . '/../Fixtures/get_object_route.php')]
 final class InvalidateObjectTest extends ConfigurableKernelTestCase
 {
+    use ArrangeCacheTest;
     use ProphecyTrait;
     use ResetDatabase;
 
@@ -30,7 +32,7 @@ final class InvalidateObjectTest extends ConfigurableKernelTestCase
         $this->cacheManager->invalidateTags(Argument::any())->willReturn($this->cacheManager->reveal());
         self::getContainer()->set('fos_http_cache.cache_manager', $this->cacheManager->reveal());
 
-        $this->object = TestObjectFactory::simple()->save();
+        $this->object = self::arrange(fn () => TestObjectFactory::simple()->save());
     }
 
     /**
@@ -47,7 +49,7 @@ final class InvalidateObjectTest extends ConfigurableKernelTestCase
     {
         $this->object->setContent('Updated test content')->save();
 
-        $this->cacheManager->invalidateTags(['o42'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['o42'])->shouldHaveBeenCalledTimes(1);
     }
 
     /**
@@ -64,6 +66,6 @@ final class InvalidateObjectTest extends ConfigurableKernelTestCase
     {
         $this->object->delete();
 
-        $this->cacheManager->invalidateTags(['o42'])->shouldHaveBeenCalled();
+        $this->cacheManager->invalidateTags(['o42'])->shouldHaveBeenCalledTimes(1);
     }
 }

--- a/tests/Integration/Tagging/TagAssetTest.php
+++ b/tests/Integration/Tagging/TagAssetTest.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Tagging;
 
 use Neusta\Pimcore\HttpCacheBundle\CacheActivator;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestAssetFactory;
 use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
@@ -13,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 #[ConfigureRoute(__DIR__ . '/../Fixtures/get_asset_route.php')]
 final class TagAssetTest extends ConfigurableWebTestcase
 {
+    use ArrangeCacheTest;
     use ResetDatabase;
 
     private KernelBrowser $client;
@@ -34,7 +36,7 @@ final class TagAssetTest extends ConfigurableWebTestcase
     ])]
     public function response_is_tagged_with_expected_tags_when_asset_is_loaded(): void
     {
-        TestAssetFactory::simple()->save();
+        self::arrange(fn () => TestAssetFactory::simple()->save());
 
         $this->client->request('GET', '/get-asset?id=42');
 
@@ -58,7 +60,7 @@ final class TagAssetTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_assets_is_not_enabled(): void
     {
-        TestAssetFactory::simple()->save();
+        self::arrange(fn () => TestAssetFactory::simple()->save());
 
         $this->client->request('GET', '/get-asset?id=42');
 
@@ -82,9 +84,8 @@ final class TagAssetTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_caching_is_deactivated(): void
     {
-        static::getContainer()->get(CacheActivator::class)->deactivateCaching();
-
-        TestAssetFactory::simple()->save();
+        self::arrange(fn () => TestAssetFactory::simple()->save());
+        self::getContainer()->get(CacheActivator::class)->deactivateCaching();
 
         $this->client->request('GET', '/get-asset?id=42');
 

--- a/tests/Integration/Tagging/TagDocumentTest.php
+++ b/tests/Integration/Tagging/TagDocumentTest.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Tagging;
 
 use Neusta\Pimcore\HttpCacheBundle\CacheActivator;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestDocumentFactory;
 use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
@@ -13,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 #[ConfigureRoute(__DIR__ . '/../Fixtures/get_document_route.php')]
 final class TagDocumentTest extends ConfigurableWebTestcase
 {
+    use ArrangeCacheTest;
     use ResetDatabase;
 
     private KernelBrowser $client;
@@ -34,7 +36,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_tagged_with_expected_tags_when_page_is_loaded(): void
     {
-        TestDocumentFactory::simplePage()->save();
+        self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $this->client->request('GET', '/test_document_page');
 
@@ -58,7 +60,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_tagged_with_expected_tags_when_snippet_is_loaded(): void
     {
-        TestDocumentFactory::simpleSnippet()->save();
+        self::arrange(fn () => TestDocumentFactory::simpleSnippet()->save());
 
         $this->client->request('GET', '/get-document?id=23');
 
@@ -82,7 +84,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_document_type_is_email(): void
     {
-        TestDocumentFactory::simpleEmail()->save();
+        self::arrange(fn () => TestDocumentFactory::simpleEmail()->save());
 
         $this->client->request('GET', '/get-document?id=17');
 
@@ -106,7 +108,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_document_type_is_hard_link(): void
     {
-        TestDocumentFactory::simpleHardLink()->save();
+        self::arrange(fn () => TestDocumentFactory::simpleHardLink()->save());
 
         $this->client->request('GET', '/get-document?id=33');
 
@@ -130,7 +132,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_document_type_is_folder(): void
     {
-        TestDocumentFactory::simpleFolder()->save();
+        self::arrange(fn () => TestDocumentFactory::simpleFolder()->save());
 
         $this->client->request('GET', '/get-document?id=97');
 
@@ -154,7 +156,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_documents_is_not_enabled(): void
     {
-        TestDocumentFactory::simplePage()->save();
+        self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $this->client->request('GET', '/test_document_page');
 
@@ -178,9 +180,8 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_caching_is_deactivated(): void
     {
-        static::getContainer()->get(CacheActivator::class)->deactivateCaching();
-
-        TestDocumentFactory::simplePage()->save();
+        self::arrange(fn () => TestDocumentFactory::simplePage()->save());
+        self::getContainer()->get(CacheActivator::class)->deactivateCaching();
 
         $this->client->request('GET', '/test_document_page');
 
@@ -204,7 +205,7 @@ final class TagDocumentTest extends ConfigurableWebTestcase
     ])]
     public function request_is_tagged_with_root_document_tag_when_loaded(): void
     {
-        TestDocumentFactory::simplePage()->save();
+        self::arrange(fn () => TestDocumentFactory::simplePage()->save());
 
         $this->client->request('GET', '/test_document_page');
 

--- a/tests/Integration/Tagging/TagObjectTest.php
+++ b/tests/Integration/Tagging/TagObjectTest.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Tagging;
 
 use Neusta\Pimcore\HttpCacheBundle\CacheActivator;
+use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\ArrangeCacheTest;
 use Neusta\Pimcore\HttpCacheBundle\Tests\Integration\Helpers\TestObjectFactory;
 use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
@@ -13,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 #[ConfigureRoute(__DIR__ . '/../Fixtures/get_object_route.php')]
 final class TagObjectTest extends ConfigurableWebTestcase
 {
+    use ArrangeCacheTest;
     use ResetDatabase;
 
     private KernelBrowser $client;
@@ -34,7 +36,7 @@ final class TagObjectTest extends ConfigurableWebTestcase
     ])]
     public function response_is_tagged_with_expected_tags_when_object_is_loaded(): void
     {
-        TestObjectFactory::simple()->save();
+        self::arrange(fn () => TestObjectFactory::simple()->save());
 
         $this->client->request('GET', '/get-object?id=42');
 
@@ -58,7 +60,7 @@ final class TagObjectTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_objects_is_not_enabled(): void
     {
-        TestObjectFactory::simple()->save();
+        self::arrange(fn () => TestObjectFactory::simple()->save());
 
         $this->client->request('GET', '/get-object?id=42');
 
@@ -82,9 +84,8 @@ final class TagObjectTest extends ConfigurableWebTestcase
     ])]
     public function response_is_not_tagged_when_caching_is_deactivated(): void
     {
-        static::getContainer()->get(CacheActivator::class)->deactivateCaching();
-
-        TestObjectFactory::simple()->save();
+        self::arrange(fn () => TestObjectFactory::simple()->save());
+        self::getContainer()->get(CacheActivator::class)->deactivateCaching();
 
         $this->client->request('GET', '/get-object?id=42');
 


### PR DESCRIPTION
Adds a helper trait that allows to run test setup without impacting caching logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Improved test reliability by standardizing test setup using a new arrangement method that temporarily disables caching during entity creation.
	- Updated multiple test classes to use this new setup approach for objects, documents, and assets.
	- Enhanced cache invalidation assertions to explicitly verify the expected number of cache invalidation calls.
	- Adjusted test sequence to ensure consistent behavior when caching is deactivated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->