### PR TITLE
Cleanup strict types declarations

### DIFF
--- a/src/Cache/CacheTagChecker.php
+++ b/src/Cache/CacheTagChecker.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 

--- a/src/Cache/CacheType.php
+++ b/src/Cache/CacheType.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 

--- a/src/Cache/CacheType/CustomCacheType.php
+++ b/src/Cache/CacheType/CustomCacheType.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
 

--- a/src/Cache/CacheType/ElementCacheType.php
+++ b/src/Cache/CacheType/ElementCacheType.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
 

--- a/src/Cache/CacheType/EmptyCacheType.php
+++ b/src/Cache/CacheType/EmptyCacheType.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
 

--- a/src/Cache/CacheTypeFactory.php
+++ b/src/Cache/CacheTypeFactory.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 

--- a/src/Element/ElementRepository.php
+++ b/src/Element/ElementRepository.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Element;
 

--- a/tests/Integration/Fixtures/get_object_route.php
+++ b/tests/Integration/Fixtures/get_object_route.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 use App\Controller\GetObjectController;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;

--- a/tests/Unit/Element/InvalidateElementListenerTest.php
+++ b/tests/Unit/Element/InvalidateElementListenerTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Neusta\Pimcore\HttpCacheBundle\Tests\Unit\Element;
 


### PR DESCRIPTION
The strict type declarations were not consistently formatted throughout the project. This MR standardizes the formatting of strict type declarations across the entire codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized the formatting of PHP files by merging the PHP opening tag and strict types declaration into a single line across multiple files. No changes to functionality or logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->