### PR TITLE
Custom exceptions

### DIFF
--- a/src/Cache/CacheTag.php
+++ b/src/Cache/CacheTag.php
@@ -13,11 +13,11 @@ final class CacheTag
         public readonly CacheType $type,
     ) {
         if ('' === trim($tag)) {
-            throw InvalidArgumentException::becauseEmptyCacheTypeIsNotAllowed();
+            throw InvalidArgumentException::becauseEmptyCacheTagIsNotAllowed();
         }
 
         if (!$type instanceof ElementCacheType && ElementCacheType::isReserved($type->toString())) {
-            throw InvalidArgumentException::becauseCacheTypeIsReserved($type->toString());
+            throw InvalidArgumentException::becauseCacheTypeIsReserved($type);
         }
     }
 

--- a/src/Cache/CacheTag.php
+++ b/src/Cache/CacheTag.php
@@ -13,7 +13,7 @@ final class CacheTag
         public readonly CacheType $type,
     ) {
         if ('' === trim($tag)) {
-            throw InvalidArgumentException::becauseEmptyCacheTagIsNotAllowed();
+            throw InvalidArgumentException::becauseCacheTagIsEmpty();
         }
 
         if (!$type instanceof ElementCacheType && ElementCacheType::isReserved($type->toString())) {

--- a/src/Cache/CacheTag.php
+++ b/src/Cache/CacheTag.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\HttpCacheBundle\Cache;
 
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\ElementCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Exception\InvalidArgumentException;
 use Pimcore\Model\Element\ElementInterface;
 
 final class CacheTag
@@ -12,14 +13,11 @@ final class CacheTag
         public readonly CacheType $type,
     ) {
         if ('' === trim($tag)) {
-            throw new \InvalidArgumentException('The cache tag must not be empty.');
+            throw InvalidArgumentException::becauseEmptyCacheTypeIsNotAllowed();
         }
 
         if (!$type instanceof ElementCacheType && ElementCacheType::isReserved($type->toString())) {
-            throw new \InvalidArgumentException(\sprintf(
-                'The cache type "%s" is reserved for Pimcore elements.',
-                $type->toString(),
-            ));
+            throw InvalidArgumentException::becauseCacheTypeIsReserved($type->toString());
         }
     }
 
@@ -31,7 +29,7 @@ final class CacheTag
     public static function fromElement(ElementInterface $element): self
     {
         if (!$id = $element->getId()) {
-            throw new \InvalidArgumentException('The given element has no id.');
+            throw InvalidArgumentException::becauseElementHasNoId();
         }
 
         return new self((string) $id, CacheTypeFactory::createFromElement($element));

--- a/src/Cache/CacheType/CustomCacheType.php
+++ b/src/Cache/CacheType/CustomCacheType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
 
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
+use Neusta\Pimcore\HttpCacheBundle\Exception\InvalidArgumentException;
 
 final class CustomCacheType implements CacheType
 {
@@ -11,7 +12,7 @@ final class CustomCacheType implements CacheType
         private readonly string $type,
     ) {
         if ('' === $this->type) {
-            throw new \InvalidArgumentException('The cache type must not be empty.');
+            throw InvalidArgumentException::becauseCacheTypeIsEmpty();
         }
     }
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -6,7 +6,7 @@ use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
 
 final class InvalidArgumentException extends \InvalidArgumentException implements PimcoreHttpCacheException
 {
-    public static function becauseEmptyCacheTagIsNotAllowed(): self
+    public static function becauseCacheTagIsEmpty(): self
     {
         return new self('Cache tag must not be empty.');
     }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,16 +2,21 @@
 
 namespace Neusta\Pimcore\HttpCacheBundle\Exception;
 
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType;
+
 final class InvalidArgumentException extends \InvalidArgumentException implements PimcoreHttpCacheException
 {
-    public static function becauseEmptyCacheTypeIsNotAllowed(): self
+    public static function becauseEmptyCacheTagIsNotAllowed(): self
     {
-        return new self('Cache type must not be empty.');
+        return new self('Cache tag must not be empty.');
     }
 
-    public static function becauseCacheTypeIsReserved(string $cacheType): self
+    public static function becauseCacheTypeIsReserved(CacheType $type): self
     {
-        return new self(\sprintf('The cache type "%s" is reserved for Pimcore elements.', $cacheType));
+        return new self(\sprintf(
+            'The cache type "%s" is reserved for Pimcore elements.',
+            $type->toString(),
+        ));
     }
 
     public static function becauseCacheTypeIsEmpty(): self

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Exception;
+
+final class InvalidArgumentException extends \InvalidArgumentException implements PimcoreHttpCacheException
+{
+    public static function becauseEmptyCacheTypeIsNotAllowed(): self
+    {
+        return new self('Cache type must not be empty.');
+    }
+
+    public static function becauseCacheTypeIsReserved(string $cacheType): self
+    {
+        return new self(\sprintf('The cache type "%s" is reserved for Pimcore elements.', $cacheType));
+    }
+
+    public static function becauseCacheTypeIsEmpty(): self
+    {
+        return new self('The cache type must not be empty.');
+    }
+
+    public static function becauseElementHasNoId(): self
+    {
+        return new self('The given element has no id.');
+    }
+}

--- a/src/Exception/PimcoreHttpCacheException.php
+++ b/src/Exception/PimcoreHttpCacheException.php
@@ -2,6 +2,9 @@
 
 namespace Neusta\Pimcore\HttpCacheBundle\Exception;
 
+/**
+ *  Interface for all exceptions thrown by the PimcoreHttpCacheBundle.
+ */
 interface PimcoreHttpCacheException
 {
 }

--- a/src/Exception/PimcoreHttpCacheException.php
+++ b/src/Exception/PimcoreHttpCacheException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Exception;
+
+interface PimcoreHttpCacheException
+{
+}


### PR DESCRIPTION
Introduces the PimcoreHttpCacheException interface to enable catching exceptions thrown by the bundle. Also adds a custom InvalidArgumentException that implements the PimcoreHttpCacheException interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced clearer, domain-specific error messages for cache-related issues through new custom exceptions and a marker interface.
- **Refactor**
  - Standardized error handling by replacing generic exceptions with specialized exception classes and factory methods for invalid cache tags, reserved cache types, empty cache types, and missing element IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->