### PR TITLE
Fix testing invalidation of deleted documents

### DIFF
--- a/tests/Integration/Invalidation/InvalidateDocumentTest.php
+++ b/tests/Integration/Invalidation/InvalidateDocumentTest.php
@@ -195,7 +195,7 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
     ])]
     public function response_is_not_invalidated_when_document_type_is_disabled_on_delete(): void
     {
-        $this->document->setKey('updated_test_document_page')->save();
+        $this->document->delete();
 
         $this->cacheManager->invalidateTags(Argument::any())->shouldNotHaveBeenCalled();
     }
@@ -215,7 +215,7 @@ final class InvalidateDocumentTest extends ConfigurableKernelTestCase
      */
     public function response_is_not_invalidated_when_documents_are_disabled_on_delete(): void
     {
-        $this->document->setKey('updated_test_document_page')->save();
+        $this->document->delete();
 
         $this->cacheManager->invalidateTags(Argument::any())->shouldNotHaveBeenCalled();
     }


### PR DESCRIPTION
This is a follow-up of #21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated integration tests to better reflect document deletion scenarios, ensuring more accurate test coverage for cache invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->