### PR TITLE
Refactor `ElementCacheTagChecker` by extracting specific tag checkers for assets, documents, and objects

### DIFF
--- a/src/Cache/CacheTagChecker/Element/AssetCacheTagChecker.php
+++ b/src/Cache/CacheTagChecker/Element/AssetCacheTagChecker.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\ElementCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
+
+final class AssetCacheTagChecker implements CacheTagChecker
+{
+    /**
+     * @param array{enabled: bool, types: array<string, bool>} $config
+     */
+    public function __construct(
+        private readonly ElementRepository $repository,
+        private readonly array $config,
+    ) {
+    }
+
+    public function isEnabled(CacheTag $tag): bool
+    {
+        \assert($tag->type instanceof ElementCacheType, \sprintf('Cache type must be an instance of %s', ElementCacheType::class));
+        \assert(ElementType::Asset === $tag->type->type, \sprintf('Cache type must be "%s"', ElementType::Asset->value));
+
+        if (!$this->config['enabled']) {
+            return false;
+        }
+
+        if (!$asset = $this->repository->findAsset((int) $tag->tag)) {
+            return false;
+        }
+
+        return $this->config['types'][$asset->getType()] ?? true;
+    }
+}

--- a/src/Cache/CacheTagChecker/Element/DocumentCacheTagChecker.php
+++ b/src/Cache/CacheTagChecker/Element/DocumentCacheTagChecker.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\ElementCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
+
+final class DocumentCacheTagChecker implements CacheTagChecker
+{
+    /**
+     * @param array{enabled: bool, types: array<string, bool>} $config
+     */
+    public function __construct(
+        private readonly ElementRepository $repository,
+        private readonly array $config,
+    ) {
+    }
+
+    public function isEnabled(CacheTag $tag): bool
+    {
+        \assert($tag->type instanceof ElementCacheType, \sprintf('Cache type must be an instance of %s', ElementCacheType::class));
+        \assert(ElementType::Document === $tag->type->type, \sprintf('Cache type must be "%s"', ElementType::Document->value));
+
+        if (!$this->config['enabled']) {
+            return false;
+        }
+
+        if (!$document = $this->repository->findDocument((int) $tag->tag)) {
+            return false;
+        }
+
+        return $this->config['types'][$document->getType()] ?? true;
+    }
+}

--- a/src/Cache/CacheTagChecker/Element/ObjectCacheTagChecker.php
+++ b/src/Cache/CacheTagChecker/Element/ObjectCacheTagChecker.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\ElementCacheType;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
+use Pimcore\Model\DataObject\Concrete;
+
+final class ObjectCacheTagChecker implements CacheTagChecker
+{
+    /**
+     * @param array{enabled: bool, types: array<string, bool>, classes: array<string, bool>} $config
+     */
+    public function __construct(
+        private readonly ElementRepository $repository,
+        private readonly array $config,
+    ) {
+    }
+
+    public function isEnabled(CacheTag $tag): bool
+    {
+        \assert($tag->type instanceof ElementCacheType, \sprintf('Cache type must be an instance of %s', ElementCacheType::class));
+        \assert(ElementType::Object === $tag->type->type, \sprintf('Cache type must be "%s"', ElementType::Object->value));
+
+        if (!$this->config['enabled']) {
+            return false;
+        }
+
+        if (!$object = $this->repository->findObject((int) $tag->tag)) {
+            return false;
+        }
+
+        if (!($this->config['types'][$object->getType()] ?? true)) {
+            return false;
+        }
+
+        if (!$object instanceof Concrete) {
+            return true;
+        }
+
+        return $this->config['classes'][$object->getClassName()] ?? true;
+    }
+}

--- a/src/Cache/CacheTagChecker/ElementCacheTagChecker.php
+++ b/src/Cache/CacheTagChecker/ElementCacheTagChecker.php
@@ -5,23 +5,15 @@ namespace Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\ElementCacheType;
-use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
 use Neusta\Pimcore\HttpCacheBundle\Element\ElementType;
-use Pimcore\Model\DataObject\Concrete;
 
 final class ElementCacheTagChecker implements CacheTagChecker
 {
-    /**
-     * @param array{enabled: bool, types: array<string, bool>}                               $assets
-     * @param array{enabled: bool, types: array<string, bool>}                               $documents
-     * @param array{enabled: bool, types: array<string, bool>, classes: array<string, bool>} $objects
-     */
     public function __construct(
         private readonly CacheTagChecker $inner,
-        private readonly ElementRepository $repository,
-        private readonly array $assets,
-        private readonly array $documents,
-        private readonly array $objects,
+        private readonly CacheTagChecker $asset,
+        private readonly CacheTagChecker $document,
+        private readonly CacheTagChecker $object,
     ) {
     }
 
@@ -32,56 +24,9 @@ final class ElementCacheTagChecker implements CacheTagChecker
         }
 
         return match ($tag->type->type) {
-            ElementType::Asset => $this->checkAsset((int) $tag->tag),
-            ElementType::Document => $this->checkDocument((int) $tag->tag),
-            ElementType::Object => $this->checkObject((int) $tag->tag),
+            ElementType::Asset => $this->asset->isEnabled($tag),
+            ElementType::Document => $this->document->isEnabled($tag),
+            ElementType::Object => $this->object->isEnabled($tag),
         };
-    }
-
-    private function checkAsset(int $id): bool
-    {
-        if (!$this->assets['enabled']) {
-            return false;
-        }
-
-        if (!$asset = $this->repository->findAsset($id)) {
-            return false;
-        }
-
-        return $this->assets['types'][$asset->getType()] ?? true;
-    }
-
-    private function checkDocument(int $id): bool
-    {
-        if (!$this->documents['enabled']) {
-            return false;
-        }
-
-        if (!$document = $this->repository->findDocument($id)) {
-            return false;
-        }
-
-        return $this->documents['types'][$document->getType()] ?? true;
-    }
-
-    private function checkObject(int $id): bool
-    {
-        if (!$this->objects['enabled']) {
-            return false;
-        }
-
-        if (!$object = $this->repository->findObject($id)) {
-            return false;
-        }
-
-        if (!($this->objects['types'][$object->getType()] ?? true)) {
-            return false;
-        }
-
-        if (!$object instanceof Concrete) {
-            return true;
-        }
-
-        return $this->objects['classes'][$object->getClassName()] ?? true;
     }
 }

--- a/src/DependencyInjection/NeustaPimcoreHttpCacheExtension.php
+++ b/src/DependencyInjection/NeustaPimcoreHttpCacheExtension.php
@@ -2,7 +2,9 @@
 
 namespace Neusta\Pimcore\HttpCacheBundle\DependencyInjection;
 
-use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\ElementCacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element\AssetCacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element\DocumentCacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element\ObjectCacheTagChecker;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\StaticCacheTagChecker;
 use Neusta\Pimcore\HttpCacheBundle\Element\InvalidateElementListener;
 use Neusta\Pimcore\HttpCacheBundle\Element\TagElementListener;
@@ -36,14 +38,15 @@ final class NeustaPimcoreHttpCacheExtension extends ConfigurableExtension
      */
     private function registerElements(ContainerBuilder $container, array $config): void
     {
-        $tagChecker = $container->getDefinition(ElementCacheTagChecker::class);
         $tagListener = $container->getDefinition(TagElementListener::class);
         $invalidateListener = $container->getDefinition(InvalidateElementListener::class);
 
         if ($config['assets']['enabled']) {
-            $tagChecker->setArgument('$assets', $config['assets']);
+            $container->getDefinition(AssetCacheTagChecker::class)
+                ->setArgument('$config', $config['assets']);
 
-            $tagListener->addTag('kernel.event_listener', ['event' => AssetEvents::POST_LOAD]);
+            $tagListener
+                ->addTag('kernel.event_listener', ['event' => AssetEvents::POST_LOAD]);
 
             $invalidateListener
                 ->addTag('kernel.event_listener', ['event' => AssetEvents::POST_UPDATE, 'method' => 'onUpdate'])
@@ -51,9 +54,11 @@ final class NeustaPimcoreHttpCacheExtension extends ConfigurableExtension
         }
 
         if ($config['documents']['enabled']) {
-            $tagChecker->setArgument('$documents', $config['documents']);
+            $container->getDefinition(DocumentCacheTagChecker::class)
+                ->setArgument('$config', $config['documents']);
 
-            $tagListener->addTag('kernel.event_listener', ['event' => DocumentEvents::POST_LOAD]);
+            $tagListener
+                ->addTag('kernel.event_listener', ['event' => DocumentEvents::POST_LOAD]);
 
             $invalidateListener
                 ->addTag('kernel.event_listener', ['event' => DocumentEvents::POST_UPDATE, 'method' => 'onUpdate'])
@@ -61,9 +66,11 @@ final class NeustaPimcoreHttpCacheExtension extends ConfigurableExtension
         }
 
         if ($config['objects']['enabled']) {
-            $tagChecker->setArgument('$objects', $config['objects']);
+            $container->getDefinition(ObjectCacheTagChecker::class)
+                ->setArgument('$config', $config['objects']);
 
-            $tagListener->addTag('kernel.event_listener', ['event' => DataObjectEvents::POST_LOAD]);
+            $tagListener
+                ->addTag('kernel.event_listener', ['event' => DataObjectEvents::POST_LOAD]);
 
             $invalidateListener
                 ->addTag('kernel.event_listener', ['event' => DataObjectEvents::POST_UPDATE, 'method' => 'onUpdate'])

--- a/tests/Unit/Cache/CacheTagChecker/Element/AssetCacheTagCheckerTest.php
+++ b/tests/Unit/Cache/CacheTagChecker/Element/AssetCacheTagCheckerTest.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Tests\Unit\Cache\CacheTagChecker\Element;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\Asset;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+final class AssetCacheTagCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<ElementRepository> */
+    private ObjectProphecy $elementRepository;
+
+    protected function setUp(): void
+    {
+        $this->elementRepository = $this->prophesize(ElementRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_asset_is_disabled(): void
+    {
+        $asset = $this->prophesize(Asset::class);
+        $elementCacheTagChecker = new CacheTagChecker\Element\AssetCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => false, 'types' => []],
+        );
+
+        $asset->getId()->willReturn(42);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($asset->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_asset_does_not_exist(): void
+    {
+        $asset = $this->prophesize(Asset::class);
+        $elementCacheTagChecker = new CacheTagChecker\Element\AssetCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => true]],
+        );
+
+        $asset->getId()->willReturn(42);
+        $this->elementRepository->findAsset(42)->willReturn(null);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($asset->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_asset_type_is_disabled(): void
+    {
+        $asset = $this->prophesize(Asset::class);
+        $elementCacheTagChecker = new CacheTagChecker\Element\AssetCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => false]],
+        );
+
+        $asset->getId()->willReturn(42);
+        $asset->getType()->willReturn('foo');
+        $this->elementRepository->findAsset(42)->willReturn($asset);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($asset->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_asset_type_is_enabled(): void
+    {
+        $asset = $this->prophesize(Asset::class);
+        $elementCacheTagChecker = new CacheTagChecker\Element\AssetCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => true]],
+        );
+
+        $asset->getId()->willReturn(42);
+        $asset->getType()->willReturn('foo');
+        $this->elementRepository->findAsset(42)->willReturn($asset);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($asset->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_asset_type_is_not_disabled(): void
+    {
+        $asset = $this->prophesize(Asset::class);
+        $elementCacheTagChecker = new CacheTagChecker\Element\AssetCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => false]],
+        );
+
+        $asset->getId()->willReturn(42);
+        $asset->getType()->willReturn('bar');
+        $this->elementRepository->findAsset(42)->willReturn($asset);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($asset->reveal()),
+        ));
+    }
+}

--- a/tests/Unit/Cache/CacheTagChecker/Element/DocumentCacheTagCheckerTest.php
+++ b/tests/Unit/Cache/CacheTagChecker/Element/DocumentCacheTagCheckerTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Tests\Unit\Cache\CacheTagChecker\Element;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element\DocumentCacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\Document;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+final class DocumentCacheTagCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<ElementRepository> */
+    private ObjectProphecy $elementRepository;
+
+    protected function setUp(): void
+    {
+        $this->elementRepository = $this->prophesize(ElementRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_document_is_disabled(): void
+    {
+        $document = $this->prophesize(Document::class);
+        $elementCacheTagChecker = new DocumentCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => false, 'types' => []],
+        );
+
+        $document->getId()->willReturn(42);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($document->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_document_does_not_exist(): void
+    {
+        $document = $this->prophesize(Document::class);
+        $elementCacheTagChecker = new DocumentCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => []],
+        );
+
+        $document->getId()->willReturn(42);
+        $this->elementRepository->findDocument(42)->willReturn(null);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($document->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_document_type_is_disabled(): void
+    {
+        $document = $this->prophesize(Document::class);
+        $elementCacheTagChecker = new DocumentCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => false]],
+        );
+
+        $document->getId()->willReturn(42);
+        $document->getType()->willReturn('foo');
+
+        $this->elementRepository->findDocument(42)->willReturn($document);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($document->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_document_type_is_enabled(): void
+    {
+        $document = $this->prophesize(Document::class);
+        $elementCacheTagChecker = new DocumentCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => true]],
+        );
+
+        $document->getId()->willReturn(42);
+        $document->getType()->willReturn('foo');
+
+        $this->elementRepository->findDocument(42)->willReturn($document);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($document->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_document_type_is_not_disabled(): void
+    {
+        $document = $this->prophesize(Document::class);
+        $elementCacheTagChecker = new DocumentCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => ['foo' => false]],
+        );
+
+        $document->getId()->willReturn(42);
+        $document->getType()->willReturn('bar');
+        $this->elementRepository->findDocument(42)->willReturn($document);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($document->reveal()),
+        ));
+    }
+}

--- a/tests/Unit/Cache/CacheTagChecker/Element/ObjectCacheTagCheckerTest.php
+++ b/tests/Unit/Cache/CacheTagChecker/Element/ObjectCacheTagCheckerTest.php
@@ -1,0 +1,184 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\HttpCacheBundle\Tests\Unit\Cache\CacheTagChecker\Element;
+
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\Element\ObjectCacheTagChecker;
+use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\AbstractObject;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+final class ObjectCacheTagCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<ElementRepository> */
+    private ObjectProphecy $elementRepository;
+
+    protected function setUp(): void
+    {
+        $this->elementRepository = $this->prophesize(ElementRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_object_is_disabled(): void
+    {
+        $object = $this->prophesize(DataObject::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => false, 'types' => [], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_object_does_not_exist(): void
+    {
+        $object = $this->prophesize(DataObject::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+        $this->elementRepository->findObject(42)->willReturn(null);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_object_type_is_disabled(): void
+    {
+        $object = $this->prophesize(DataObject::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [AbstractObject::OBJECT_TYPE_FOLDER => false], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn(AbstractObject::OBJECT_TYPE_FOLDER);
+        $this->elementRepository->findObject(42)->willReturn($object);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_object_type_is_enabled(): void
+    {
+        $object = $this->prophesize(DataObject::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [AbstractObject::OBJECT_TYPE_VARIANT => true], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn(AbstractObject::OBJECT_TYPE_VARIANT);
+        $this->elementRepository->findObject(42)->willReturn($object);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_object_type_is_not_disabled(): void
+    {
+        $object = $this->prophesize(DataObject::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [AbstractObject::OBJECT_TYPE_FOLDER => false], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn(AbstractObject::OBJECT_TYPE_OBJECT);
+        $this->elementRepository->findObject(42)->willReturn($object);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_object_is_not_concrete(): void
+    {
+        $object = $this->prophesize(DataObject::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn(AbstractObject::OBJECT_TYPE_OBJECT);
+        $this->elementRepository->findObject(42)->willReturn($object);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_true_when_class_is_not_disabled(): void
+    {
+        $object = $this->prophesize(DataObject\Concrete::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [], 'classes' => []],
+        );
+
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn(AbstractObject::OBJECT_TYPE_OBJECT);
+        $object->getClassName()->willReturn('Foo');
+        $this->elementRepository->findObject(42)->willReturn($object);
+
+        self::assertTrue($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_false_when_class_is_disabled(): void
+    {
+        $object = $this->prophesize(DataObject\Concrete::class);
+        $elementCacheTagChecker = new ObjectCacheTagChecker(
+            $this->elementRepository->reveal(),
+            config: ['enabled' => true, 'types' => [], 'classes' => ['Foo' => false]],
+        );
+
+        $object->getId()->willReturn(42);
+        $object->getType()->willReturn(AbstractObject::OBJECT_TYPE_OBJECT);
+        $object->getClassName()->willReturn('Foo');
+        $this->elementRepository->findObject(42)->willReturn($object);
+
+        self::assertFalse($elementCacheTagChecker->isEnabled(
+            CacheTag::fromElement($object->reveal()),
+        ));
+    }
+}

--- a/tests/Unit/Cache/CacheTagChecker/ElementCacheTagCheckerTest.php
+++ b/tests/Unit/Cache/CacheTagChecker/ElementCacheTagCheckerTest.php
@@ -6,11 +6,11 @@ use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTagChecker\ElementCacheTagChecker;
 use Neusta\Pimcore\HttpCacheBundle\Cache\CacheType\CustomCacheType;
-use Neusta\Pimcore\HttpCacheBundle\Element\ElementRepository;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
@@ -18,373 +18,92 @@ final class ElementCacheTagCheckerTest extends TestCase
 {
     use ProphecyTrait;
 
+    private ElementCacheTagChecker $elementCacheTagChecker;
+
     /** @var ObjectProphecy<CacheTagChecker> */
     private ObjectProphecy $innerCacheTagChecker;
-
-    /** @var ObjectProphecy<ElementRepository> */
-    private ObjectProphecy $elementRepository;
+    /** @var ObjectProphecy<CacheTagChecker> */
+    private ObjectProphecy $assetCacheTagChecker;
+    /** @var ObjectProphecy<CacheTagChecker> */
+    private ObjectProphecy $documentCacheTagChecker;
+    /** @var ObjectProphecy<CacheTagChecker> */
+    private ObjectProphecy $objectCacheTagChecker;
 
     protected function setUp(): void
     {
         $this->innerCacheTagChecker = $this->prophesize(CacheTagChecker::class);
-        $this->elementRepository = $this->prophesize(ElementRepository::class);
+        $this->assetCacheTagChecker = $this->prophesize(CacheTagChecker::class);
+        $this->documentCacheTagChecker = $this->prophesize(CacheTagChecker::class);
+        $this->objectCacheTagChecker = $this->prophesize(CacheTagChecker::class);
+
+        $this->innerCacheTagChecker->isEnabled(Argument::any())->willReturn(false);
+        $this->assetCacheTagChecker->isEnabled(Argument::any())->willReturn(false);
+        $this->documentCacheTagChecker->isEnabled(Argument::any())->willReturn(false);
+        $this->objectCacheTagChecker->isEnabled(Argument::any())->willReturn(false);
+
+        $this->elementCacheTagChecker = new ElementCacheTagChecker(
+            inner: $this->innerCacheTagChecker->reveal(),
+            asset: $this->assetCacheTagChecker->reveal(),
+            document: $this->documentCacheTagChecker->reveal(),
+            object: $this->objectCacheTagChecker->reveal(),
+        );
     }
 
     /**
      * @test
      */
-    public function it_delegates_cache_tag_check_to_next_cache_tag_checker(): void
+    public function it_delegates_to_next_checker_when_not_an_element(): void
     {
         $tag = CacheTag::fromString('foo', new CustomCacheType('custom'));
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => true, 'types' => ['foo' => true]],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
 
         $this->innerCacheTagChecker->isEnabled($tag)->willReturn(true);
 
-        self::assertTrue($elementCacheTagChecker->isEnabled($tag));
+        self::assertTrue($this->elementCacheTagChecker->isEnabled($tag));
         $this->innerCacheTagChecker->isEnabled($tag)->shouldHaveBeenCalledOnce();
     }
 
     /**
      * @test
      */
-    public function it_returns_false_when_asset_is_disabled(): void
+    public function it_delegates_to_asset_checker(): void
     {
         $asset = $this->prophesize(Asset::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
         $asset->getId()->willReturn(42);
+        $tag = CacheTag::fromElement($asset->reveal());
 
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($asset->reveal()),
-        ));
+        $this->assetCacheTagChecker->isEnabled($tag)->willReturn(true);
+
+        self::assertTrue($this->elementCacheTagChecker->isEnabled($tag));
+        $this->assetCacheTagChecker->isEnabled($tag)->shouldHaveBeenCalledOnce();
     }
 
     /**
      * @test
      */
-    public function it_returns_false_when_asset_does_not_exist(): void
-    {
-        $asset = $this->prophesize(Asset::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => true, 'types' => ['foo' => true]],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
-        $asset->getId()->willReturn(42);
-        $this->elementRepository->findAsset(42)->willReturn(null);
-
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($asset->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_false_when_asset_type_is_disabled(): void
-    {
-        $asset = $this->prophesize(Asset::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => true, 'types' => ['foo' => false]],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
-        $asset->getId()->willReturn(42);
-        $asset->getType()->willReturn('foo');
-        $this->elementRepository->findAsset(42)->willReturn($asset);
-
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($asset->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_true_when_asset_type_is_enabled(): void
-    {
-        $asset = $this->prophesize(Asset::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => true, 'types' => ['foo' => true]],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
-        $asset->getId()->willReturn(42);
-        $asset->getType()->willReturn('foo');
-        $this->elementRepository->findAsset(42)->willReturn($asset);
-
-        self::assertTrue($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($asset->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_true_when_asset_type_is_not_disabled(): void
-    {
-        $asset = $this->prophesize(Asset::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => true, 'types' => ['foo' => false]],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
-        $asset->getId()->willReturn(42);
-        $asset->getType()->willReturn('bar');
-        $this->elementRepository->findAsset(42)->willReturn($asset);
-
-        self::assertTrue($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($asset->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_false_when_document_is_disabled(): void
+    public function it_delegates_to_document_checker(): void
     {
         $document = $this->prophesize(Document::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
         $document->getId()->willReturn(42);
+        $tag = CacheTag::fromElement($document->reveal());
 
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($document->reveal()),
-        ));
+        $this->documentCacheTagChecker->isEnabled($tag)->willReturn(true);
+
+        self::assertTrue($this->elementCacheTagChecker->isEnabled($tag));
+        $this->documentCacheTagChecker->isEnabled($tag)->shouldHaveBeenCalledOnce();
     }
 
     /**
      * @test
      */
-    public function it_returns_false_when_document_does_not_exist(): void
-    {
-        $document = $this->prophesize(Document::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
-        $document->getId()->willReturn(42);
-        $this->elementRepository->findDocument(42)->willReturn(null);
-
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($document->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_false_when_document_type_is_disabled(): void
-    {
-        $document = $this->prophesize(Document::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => true, 'types' => ['foo' => false]],
-            objects: ['enabled' => false],
-        );
-
-        $document->getId()->willReturn(42);
-        $document->getType()->willReturn('foo');
-
-        $this->elementRepository->findDocument(42)->willReturn($document);
-
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($document->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_true_when_document_type_is_enabled(): void
-    {
-        $document = $this->prophesize(Document::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => true, 'types' => ['foo' => true]],
-            objects: ['enabled' => false],
-        );
-
-        $document->getId()->willReturn(42);
-        $document->getType()->willReturn('foo');
-
-        $this->elementRepository->findDocument(42)->willReturn($document);
-
-        self::assertTrue($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($document->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_true_when_document_type_is_not_disabled(): void
-    {
-        $document = $this->prophesize(Document::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => true, 'types' => ['foo' => false]],
-            objects: ['enabled' => false],
-        );
-
-        $document->getId()->willReturn(42);
-        $document->getType()->willReturn('bar');
-        $this->elementRepository->findDocument(42)->willReturn($document);
-
-        self::assertTrue($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($document->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_false_when_object_is_disabled(): void
+    public function it_delegates_to_object_checker(): void
     {
         $object = $this->prophesize(DataObject::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
         $object->getId()->willReturn(42);
+        $tag = CacheTag::fromElement($object->reveal());
 
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($object->reveal()),
-        ));
-    }
+        $this->objectCacheTagChecker->isEnabled($tag)->willReturn(true);
 
-    /**
-     * @test
-     */
-    public function it_returns_false_when_object_does_not_exist(): void
-    {
-        $object = $this->prophesize(DataObject::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => false],
-        );
-
-        $object->getId()->willReturn(42);
-        $this->elementRepository->findObject(42)->willReturn(null);
-
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($object->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_false_when_object_type_is_disabled(): void
-    {
-        $object = $this->prophesize(DataObject::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => true, 'types' => ['foo' => false]],
-        );
-
-        $object->getId()->willReturn(42);
-        $object->getType()->willReturn('foo');
-        $this->elementRepository->findObject(42)->willReturn($object);
-
-        self::assertFalse($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($object->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_true_when_object_type_is_enabled(): void
-    {
-        $object = $this->prophesize(DataObject::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => true, 'types' => ['foo' => true]],
-        );
-
-        $object->getId()->willReturn(42);
-        $object->getType()->willReturn('foo');
-        $this->elementRepository->findObject(42)->willReturn($object);
-
-        self::assertTrue($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($object->reveal()),
-        ));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_true_when_object_type_is_not_disabled(): void
-    {
-        $object = $this->prophesize(DataObject::class);
-        $elementCacheTagChecker = new ElementCacheTagChecker(
-            $this->innerCacheTagChecker->reveal(),
-            $this->elementRepository->reveal(),
-            assets: ['enabled' => false],
-            documents: ['enabled' => false],
-            objects: ['enabled' => true, 'types' => ['foo' => false]],
-        );
-
-        $object->getId()->willReturn(42);
-        $object->getType()->willReturn('bar');
-        $this->elementRepository->findObject(42)->willReturn($object);
-
-        self::assertTrue($elementCacheTagChecker->isEnabled(
-            CacheTag::fromElement($object->reveal()),
-        ));
+        self::assertTrue($this->elementCacheTagChecker->isEnabled($tag));
+        $this->objectCacheTagChecker->isEnabled($tag)->shouldHaveBeenCalledOnce();
     }
 }


### PR DESCRIPTION
What do you think of this?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced specialized cache tag checkers for assets, documents, and objects, allowing more granular control over cache tag enablement.

* **Refactor**
  * Refactored the cache tag checking system to delegate logic to the new specialized checkers, improving modularity and maintainability.

* **Tests**
  * Added comprehensive unit tests for the new asset, document, and object cache tag checkers.
  * Updated existing tests to verify correct delegation to specialized checkers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->