### PR TITLE
Add `withoutAutomaticTagging` method to `CacheActivator`

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -24,11 +24,13 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service_closure;
 
 return static function (ContainerConfigurator $configurator) {
     $services = $configurator->services();
 
     $services->set('neusta_pimcore_http_cache.cache_activator', CacheActivator::class)
+        ->arg('$responseTagger', service_closure('neusta_pimcore_http_cache.response_tagger'))
         ->alias(CacheActivator::class, 'neusta_pimcore_http_cache.cache_activator');
 
     $services->set('neusta_pimcore_http_cache.cache_invalidator', CacheInvalidatorAdapter::class)

--- a/src/CacheActivator.php
+++ b/src/CacheActivator.php
@@ -2,9 +2,17 @@
 
 namespace Neusta\Pimcore\HttpCacheBundle;
 
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTag;
+use Neusta\Pimcore\HttpCacheBundle\Cache\CacheTags;
+
 final class CacheActivator
 {
     private bool $isCachingActive = true;
+
+    public function __construct(
+        private readonly \Closure $responseTagger,
+    ) {
+    }
 
     public function isCachingActive(): bool
     {
@@ -19,5 +27,51 @@ final class CacheActivator
     public function deactivateCaching(): void
     {
         $this->isCachingActive = false;
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): (T|\Generator<int, CacheTag|CacheTags, null, T>) $fn
+     *
+     * @return T
+     */
+    public function withoutAutomaticTagging(\Closure $fn): mixed
+    {
+        $previous = $this->isCachingActive;
+        $this->isCachingActive = false;
+
+        $tags = new CacheTags();
+
+        try {
+            $result = $fn();
+
+            if ($result instanceof \Generator) {
+                $index = 0;
+                foreach ($result as $key => $yielded) {
+                    ++$index;
+
+                    if (!$yielded instanceof CacheTag && !$yielded instanceof CacheTags) {
+                        throw new \LogicException(\sprintf(
+                            'Invalid yielded value at index %d (key: %s): Expected only "%s" or "%s", got "%s".',
+                            $index,
+                            \is_int($key) || \is_string($key) ? $key : get_debug_type($key),
+                            CacheTag::class,
+                            CacheTags::class,
+                            get_debug_type($yielded),
+                        ));
+                    }
+
+                    $tags = $tags->with($yielded);
+                }
+
+                $result = $result->getReturn();
+            }
+        } finally {
+            $this->isCachingActive = $previous;
+            ($this->responseTagger)()->tag($tags);
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
This allows the automatic tagging to be disabled for certain code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced HTTP cache handling with optimized lazy-loading of cache components for improved efficiency.

* **Enhancements**
  * Added capability to temporarily disable automatic caching with automatic tag aggregation and restoration to original state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->